### PR TITLE
Fix typos and grammar in index.Rmd

### DIFF
--- a/inst/tutorials/learndrakestatic/index.Rmd
+++ b/inst/tutorials/learndrakestatic/index.Rmd
@@ -725,7 +725,7 @@ drake_plan(
 
 ## Target names
 
-The names of static branching targets can get quite long. The custom `.id` argument of `map()` to exclude the values of `fun_run` from the names, e.g. `.id = act_values` or `.id = c(act_values, unit_values)`. (`.id = FALSE` shortens the names even more.)
+The names of static branching targets can get quite long. Use the custom `.id` argument of `map()` to exclude the values of `fun_run` from the names, e.g. `.id = act_values` or `.id = c(act_values, unit_values)`. (`.id = FALSE` shortens the names even more.)
 
 ```{r}
 grid <- tibble::tibble(
@@ -739,7 +739,7 @@ expected <- drake_plan(
   churn_recipe = prepare_recipe(churn_data), 
   run = target(
     fun_run(churn_data, churn_recipe, act1 = act_values, units = units_values),
-    transform = map(.data = !!grid, .id = c(act_values, unit_values))
+    transform = map(.data = !!grid, .id = c(act_values, units_values))
   )
 )
 ```
@@ -752,7 +752,7 @@ dp_table(expected)
 dp_graph(expected)
 ```
 
-Create the above plan. Use `act_values` and `unit_values` to construct target names.
+Create the above plan. Use `act_values` and `units_values` to construct target names.
 
 ```{r names, exercise = TRUE, exercise.lines = 17, paged.print = FALSE}
 grid <- tibble::tibble(
@@ -775,7 +775,7 @@ drake_plan(
 ```
 
 ```{r names-hint-1}
-transform = map(.data = !!grid, .id = c(act_values, unit_values))
+transform = map(.data = !!grid, .id = c(act_values, units_values))
 ```
 
 ```{r names-hint-2}
@@ -794,7 +794,7 @@ drake_plan(
   churn_recipe = prepare_recipe(churn_data), 
   run = target(
     fun_run(churn_data, churn_recipe, act1 = act_values, units = units_values),
-    transform = map(.data = !!grid, .id = c(act_values, unit_values))
+    transform = map(.data = !!grid, .id = c(act_values, units_values))
   )
 )
 ```
@@ -810,7 +810,7 @@ drake_plan(
   churn_recipe = prepare_recipe(churn_data), 
   run = target(
     fun_run(churn_data, churn_recipe, act1 = act_values, units = units_values),
-    transform = map(.data = !!grid, .id = c(act_values, unit_values))
+    transform = map(.data = !!grid, .id = c(act_values, units_values))
   )
 )
 ```


### PR DESCRIPTION
# Summary

1. `unit_values` is used but not defined, `units_values` is defined but not used. I reason it's a typo.
2. Minor grammar correction.

# Checklist

- [x] I understand and agree to `learndrake`'s [code of conduct](https://github.com/wlandau/learndrake/blob/master/CODE_OF_CONDUCT.md).
- [x] I have listed any substantial changes in the [development news](https://github.com/wlandau/learndrake/blob/master/NEWS.md).
- [x] This pull request is not a [draft](https://github.blog/2019-02-14-introducing-draft-pull-requests).
